### PR TITLE
Ensure that there is a footer that complies with the policy.

### DIFF
--- a/project.css
+++ b/project.css
@@ -14,3 +14,7 @@
 	margin-left: 1.5em;
 	padding: 0;
 }
+
+#copyright {
+	padding-left: 0;
+}

--- a/project.js
+++ b/project.js
@@ -163,6 +163,51 @@ function generateBody() {
 	</main>
 	<footer id="footer">
 		<div class="container">
+			<div class="footer-sections row equal-height-md font-bold">
+				<div id="footer-eclipse-foundation" class="footer-section col-md-5 col-sm-8">
+					<div class="menu-heading">Eclipse Foundation</div>
+					<ul class="nav">
+						<ul class="nav">
+							<li><a href="http://www.eclipse.org/org/">About</a></li>
+							<li><a href="https://projects.eclipse.org/">Projects</a></li>
+							<li><a href="http://www.eclipse.org/collaborations/">Collaborations</a></li>
+							<li><a href="http://www.eclipse.org/membership/">Membership</a></li>
+							<li><a href="http://www.eclipse.org/sponsor/">Sponsor</a></li>
+						</ul>
+					</ul>
+				</div>
+				<div id="footer-legal" class="footer-section col-md-5 col-sm-8">
+					<div class="menu-heading">Legal</div>
+					<ul class="nav">
+						<ul class="nav">
+							<li><a href="http://www.eclipse.org/legal/privacy.php">Privacy Policy</a></li>
+							<li><a href="http://www.eclipse.org/legal/termsofuse.php">Terms of Use</a></li>
+							<li><a href="http://www.eclipse.org/legal/compliance/">Compliance</a></li>
+							<li><a href="http://www.eclipse.org/org/documents/Community_Code_of_Conduct.php">Code of
+									Conduct</a></li>
+							<li><a href="http://www.eclipse.org/legal/">Legal Resources</a></li>
+						</ul>
+					</ul>
+				</div>
+				<div id="footer-more" class="footer-section col-md-5 col-sm-8">
+					<div class="menu-heading">More</div>
+					<ul class="nav">
+						<ul class="nav">
+							<li><a href="http://www.eclipse.org/security/">Report a Vulnerability</a></li>
+							<li><a href="https://www.eclipsestatus.io/">Service Status</a></li>
+							<li><a href="http://www.eclipse.org/org/foundation/contact.php">Contact</a></li>
+							<li><a href="http://www.eclipse.org//projects/support/">Support</a></li>
+						</ul>
+					</ul>
+				</div>
+			</div>
+			<div class="col-sm-24">
+				<div class="row">
+					<div id="copyright" class="col-md-16">
+						<p id="copyright-text">Copyright © Eclipse Foundation AISBL. All Rights Reserved.</p>
+					</div>
+				</div>
+			</div>
 			<a href="#" class="scrollup" onclick="scrollToTop()">Back to the top</a>
 		</div>
 	</footer>


### PR DESCRIPTION
This is the policy:

https://www.eclipse.org/org/documents/eclipse-foundation-hosted-services-privacy-and-acceptable-usage-policy.pdf

The footer looks like this:

![image](https://github.com/user-attachments/assets/b51a7b09-70a6-410d-b0e5-f258c1b1eb5b)

Like on the standard pages:

https://eclipse.dev/justj/